### PR TITLE
Better modelling of errors.

### DIFF
--- a/bin/sus
+++ b/bin/sus
@@ -28,6 +28,6 @@ config.after_tests(assertions)
 #
 # $ stackprof sus.stackprof --text --limit 10
 
-if assertions.failed.any?
+unless assertions.passed?
 	exit(1)
 end

--- a/bin/sus-parallel
+++ b/bin/sus-parallel
@@ -65,6 +65,6 @@ results.close
 assertions = aggregation.value
 config.after_tests(assertions)
 
-if assertions.failed.any?
+unless assertions.passed?
 	exit(1)
 end

--- a/lib/sus/be.rb
+++ b/lib/sus/be.rb
@@ -16,7 +16,9 @@ module Sus
 		end
 		
 		def call(assertions, subject)
-			assertions.assert(subject.public_send(*@arguments), self)
+			assertions.nested(self) do |assertions|
+				assertions.assert(subject.public_send(*@arguments))
+			end
 		end
 		
 		class << self

--- a/lib/sus/config.rb
+++ b/lib/sus/config.rb
@@ -116,13 +116,13 @@ module Sus
 			
 			assertions.print(output)
 			output.puts
-
+			
 			print_finished_statistics(assertions)
-
+			
 			if !partial? and assertions.passed?
 				print_test_feedback(assertions)
 			end
-						
+			
 			print_slow_tests(assertions)
 			print_failed_assertions(assertions)
 		end
@@ -193,14 +193,22 @@ module Sus
 			end
 		end
 		
-		def print_failed_assertions(assertions)
-			if assertions.failed.any?
+		def print_assertions(title, assertions)
+			if assertions.any?
 				output.puts
+				output.puts title
 				
-				assertions.failed.each do |failure|
-					output.append(failure.output)
+				assertions.each do |assertion|
+					assertions.each do |failure|
+						output.append(failure.output)
+					end
 				end
 			end
+		end
+		
+		def print_failed_assertions(assertions)
+			print_assertions("🤔 Failed assertions:", assertions.failed)
+			print_assertions("🔥 Errored assertions:", assertions.errored)
 		end
 	end
 end

--- a/lib/sus/output.rb
+++ b/lib/sus/output.rb
@@ -39,8 +39,9 @@ module Sus
 			
 			output[:passed] = output.style(:green)
 			output[:failed] = output.style(:red)
-			output[:error] = output.style(:red)
-			output[:skip] = output.style(:blue)
+			output[:deferred] = output.style(:yellow)
+			output[:skipped] = output.style(:blue)
+			output[:errored] = output.style(:red)
 			# output[:inform] = output.style(nil, nil, :bold)
 			
 			return output

--- a/test/sus/expect.rb
+++ b/test/sus/expect.rb
@@ -11,4 +11,14 @@ describe Sus::Expect do
 			expect(target).to be == {}
 		end
 	end
+	
+	with "exceptions" do
+		let(:assertions) {Sus::Assertions.new}
+		let(:expectation) {Sus::Expect.new(assertions, Object.new)}
+		
+		it "is expected to propagate errors" do
+			expectation.not.to be(:no_such_method?)
+			expect(assertions).to be(:errored?)
+		end
+	end
 end


### PR DESCRIPTION
If a nested assertion raises an error, previously it was marking it as a failure. However, for inverted assertions, this was considered a success. We should explicitly model errors, so that they cause a failure no matter the orientation of the assertions.