### PR TITLE
feat: Filter backtrace by root (default), or show full backtrace with verbose option

### DIFF
--- a/lib/sus/assertions.rb
+++ b/lib/sus/assertions.rb
@@ -248,7 +248,7 @@ module Sus
 				end
 			end
 		end
-		
+
 		class Error
 			def initialize(identity, error)
 				@identity = identity
@@ -272,18 +272,18 @@ module Sus
 		
 		def error!(error)
 			identity = @identity&.scoped(error.backtrace_locations)
-			
+
 			@errored << Error.new(identity, error)
-			
+
 			lines = error.message.split(/\r?\n/)
-			
+
 			@output.puts(:indent, *error_prefix, error.class, ": ", lines.shift)
 			
 			lines.each do |line|
 				@output.puts(:indent, line)
 			end
 
-			@output.write(Output::Backtrace.for(error, @identity, verbose: @verbose))
+			@output.write(Output::Backtrace.for(error, verbose: @verbose))
 		end
 		
 		def nested(target, identity: nil, isolated: false, distinct: false, inverted: false, **options)

--- a/lib/sus/assertions.rb
+++ b/lib/sus/assertions.rb
@@ -282,8 +282,8 @@ module Sus
 			lines.each do |line|
 				@output.puts(:indent, line)
 			end
-				
-			@output.write(Output::Backtrace.for(error, @identity))
+
+			@output.write(Output::Backtrace.for(error, @identity, verbose: @verbose))
 		end
 		
 		def nested(target, identity: nil, isolated: false, distinct: false, inverted: false, **options)

--- a/lib/sus/output/backtrace.rb
+++ b/lib/sus/output/backtrace.rb
@@ -12,10 +12,8 @@ module Sus
 				self.new(caller_locations(1), identity&.path, 1)
 			end
 			
-			def self.for(exception, identity = nil)
-				# I've disabled the root filter here, because partial backtraces are not very useful.
-				# We might want to do something to improve presentation of the backtrace based on the root instead.
-				self.new(exception.backtrace_locations) # , identity&.path)
+			def self.for(exception, identity = nil, verbose: false)
+				self.new(exception.backtrace_locations, verbose ? nil : identity&.path)
 			end
 			
 			def initialize(stack, root = nil, limit = nil)


### PR DESCRIPTION
This addresses #22 and now filters backtraces to the root by default.

Passing the `--verbose` arg will enable full backtraces.

Thx for an amazingly versatile testing lib :+1: