### PR TITLE
Ensure JSON is generated with string values.

### DIFF
--- a/lib/sus/tree.rb
+++ b/lib/sus/tree.rb
@@ -20,7 +20,7 @@ module Sus
 		
 		def to_json(options = nil)
 			traverse do |context|
-				[context.identity, context.description, context.leaf?]
+				[context.identity.to_s, context.description.to_s, context.leaf?]
 			end.to_json(options)
 		end
 	end


### PR DESCRIPTION
Fixes <https://github.com/ioquatix/sus-vscode/issues/1>.

Something in Rails was changing the behaviour - instead of calling `#to_s` it was trying to dump the entire object. Add `#to_s` to force the correct behaviour.