### PR TITLE
Shorter backtrace.

### DIFF
--- a/lib/sus/identity.rb
+++ b/lib/sus/identity.rb
@@ -15,6 +15,10 @@ module Sus
 			self.new(location.path, name, location.lineno, parent, **options)
 		end
 		
+		def self.current
+			self.nested(nil, nil, caller_locations(1...2).first)
+		end
+		
 		# @parameter unique [Boolean | Symbol] Whether this identity is unique or needs a unique key/line number suffix.
 		def initialize(path, name = nil, line = nil, parent = nil, unique: true)
 			@path = path

--- a/lib/sus/output/backtrace.rb
+++ b/lib/sus/output/backtrace.rb
@@ -15,7 +15,7 @@ module Sus
 			def self.for(exception, identity = nil)
 				# I've disabled the root filter here, because partial backtraces are not very useful.
 				# We might want to do something to improve presentation of the backtrace based on the root instead.
-				self.new(exception.backtrace_locations) # , identity&.path)
+				self.new(exception.backtrace_locations, identity&.path)
 			end
 			
 			def initialize(stack, root = nil, limit = nil)
@@ -26,18 +26,20 @@ module Sus
 			
 			def filter(root = @root)
 				if @root
-					stack = @stack.select do |frame|
-						frame.path.start_with?(@root)
+					if @limit
+						return @stack.lazy.select do |frame|
+							frame.path.start_with?(@root)
+						end.first(@limit)
+					else
+						return up_to_and_matching(@stack) do |frame|
+							frame.path.start_with?(@root)
+						end
 					end
+				elsif @limit
+					return @stack.first(@limit)
 				else
-					stack = @stack
+					return @stack
 				end
-				
-				if @limit
-					stack = stack.take(@limit)
-				end
-				
-				return stack
 			end
 			
 			def print(output)
@@ -50,6 +52,22 @@ module Sus
 						filter.each do |frame|
 							output.puts :indent, :path, frame.path, :line, ":", frame.lineno, :reset, " ", frame.label
 						end
+					end
+				end
+			end
+			
+			private def up_to_and_matching(things, &block)
+				preface = true
+				things.select do |thing|
+					if preface
+						if yield(thing)
+							preface = false
+						end
+						true
+					elsif yield(thing)
+						true
+					else
+						false
 					end
 				end
 			end

--- a/lib/sus/output/backtrace.rb
+++ b/lib/sus/output/backtrace.rb
@@ -24,19 +24,23 @@ module Sus
 				@limit = limit
 			end
 			
-			def filter(root = @root)
-				if @root
-					if @limit
+			attr :stack
+			attr :root
+			attr :limit
+			
+			def filter(root: @root, limit: @limit)
+				if root
+					if limit
 						return @stack.lazy.select do |frame|
-							frame.path.start_with?(@root)
-						end.first(@limit)
+							frame.path.start_with?(root)
+						end.first(limit)
 					else
 						return up_to_and_matching(@stack) do |frame|
-							frame.path.start_with?(@root)
+							frame.path.start_with?(root)
 						end
 					end
-				elsif @limit
-					return @stack.first(@limit)
+				elsif limit
+					return @stack.first(limit)
 				else
 					return @stack
 				end

--- a/test/sus/output/backtrace.rb
+++ b/test/sus/output/backtrace.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Samuel Williams.
+
+require 'sus/output/status'
+
+describe Sus::Output::Backtrace do
+	let(:identity) {Sus::Identity.current}
+	let(:backtrace) {subject.new(caller_locations)}
+	
+	it "has several frames" do
+		expect(backtrace.stack).to have_attributes(size: be >= 1)
+	end
+	
+	with "a limit of one" do
+		it "has exactly one frame" do
+			expect(backtrace.filter(limit: 1)).to have_attributes(size: be == 1)
+		end
+	end
+	
+	with "a root directory" do
+		it "has frames in the root directory" do
+			stack = backtrace.filter(root: identity.path)
+			expect(stack.size).to be >= 1
+			expect(stack.last.path).to be(:start_with?, identity.path)
+		end
+	end
+end


### PR DESCRIPTION
Truncate backtraces beyond the test as they are not relevant.

Fixes #22. Or at least, is an improvement towards it.