### PR TITLE
Always print out asertion passed/failed.

### DIFF
--- a/lib/sus/assertions.rb
+++ b/lib/sus/assertions.rb
@@ -192,16 +192,10 @@ module Sus
 			
 			if condition
 				@passed << assert
-				
-				if !@orientation || @verbose
-					@output.assert(condition, @orientation, message || "assertion passed", backtrace)
-				end
+				@output.assert(condition, @orientation, message || "assertion passed", backtrace)
 			else
 				@failed << assert
-				
-				if @orientation || @verbose
-					@output.assert(condition, @orientation, message || "assertion failed", backtrace)
-				end
+				@output.assert(condition, @orientation, message || "assertion failed", backtrace)
 			end
 		end
 		


### PR DESCRIPTION
Originally, the output was always printed. So I only printed failed assertions to bring attention to them. Now, only failed examples are printed, so let's print more detail. It's useful to see the full scope of assertions.