### PR TITLE
Correctly handle exceptions where `backtrace_locations` is `nil`.

### DIFF
--- a/lib/sus/output/backtrace.rb
+++ b/lib/sus/output/backtrace.rb
@@ -15,7 +15,21 @@ module Sus
 			def self.for(exception, identity = nil)
 				# I've disabled the root filter here, because partial backtraces are not very useful.
 				# We might want to do something to improve presentation of the backtrace based on the root instead.
-				self.new(exception.backtrace_locations, identity&.path)
+				self.new(extract_stack(exception), identity&.path)
+			end
+			
+			Location = Struct.new(:path, :lineno, :label)
+			
+			def self.extract_stack(exception)
+				if stack = exception.backtrace_locations
+					return stack
+				elsif stack = exception.backtrace
+					return stack.map do |line|
+						Location.new(*line.split(":", 3))
+					end
+				else
+					[]
+				end
 			end
 			
 			def initialize(stack, root = nil, limit = nil)

--- a/test/sus/output/backtrace.rb
+++ b/test/sus/output/backtrace.rb
@@ -26,4 +26,20 @@ describe Sus::Output::Backtrace do
 			expect(stack.last.path).to be(:start_with?, identity.path)
 		end
 	end
+	
+	with "a wonky exception" do
+		let(:exception) {Exception.new}
+		
+		it "has a backtrace" do
+			# This causes the exception to have a backtrace but not backtrace_locations.
+			exception.set_backtrace(caller)
+			
+			stack = subject.extract_stack(exception)
+			expect(stack).to be_a(Array)
+			expect(stack).to have_attributes(size: be >= 1)
+			
+			# This is a compatibility wrapper...
+			expect(stack.first).to be_a(Sus::Output::Backtrace::Location)
+		end
+	end
 end


### PR DESCRIPTION
Work-around for https://github.com/SeleniumHQ/selenium/issues/13221