### PR TITLE
Print cause of exception.

### DIFF
--- a/lib/sus/output/messages.rb
+++ b/lib/sus/output/messages.rb
@@ -54,16 +54,20 @@ module Sus
 				[:errored, "⚠ "]
 			end
 			
-			def error(error, identity)
+			def error(error, identity, prefix = error_prefix)
 				lines = error.message.split(/\r?\n/)
 			
-				self.puts(:indent, *error_prefix, error.class, ": ", lines.shift)
+				self.puts(:indent, *prefix, error.class, ": ", lines.shift)
 				
 				lines.each do |line|
 					self.puts(:indent, line)
 				end
 					
 				self.write(Output::Backtrace.for(error, identity))
+				
+				if cause = error.cause
+					self.error(cause, identity, ["Caused by ", :errored])
+				end
 			end
 			
 			def inform_prefix


### PR DESCRIPTION
Before:

```
🔥 Errored assertions:
describe Async::HTTP::Internet it can fetch remote website when given custom endpoint instead of url test/async/http/internet.rb:37
	⚠ NoMethodError: undefined method `close' for nil
		test/async/http/internet.rb:48 ensure in block (3 levels) in <top (required)>
		test/async/http/internet.rb:48 block (3 levels) in <top (required)>
```

After:

```
🔥 Errored assertions:
describe Async::HTTP::Internet it can fetch remote website when given custom endpoint instead of url test/async/http/internet.rb:37
	⚠ NoMethodError: undefined method `close' for nil
		test/async/http/internet.rb:48 ensure in block (3 levels) in <top (required)>
		test/async/http/internet.rb:48 block (3 levels) in <top (required)>
	Caused by NoMethodError: undefined method `get' for class Async::HTTP::Internet
		test/async/http/internet.rb:44 block (3 levels) in <top (required)>
```