### PR TITLE
Include context safety

### DIFF
--- a/lib/sus/context.rb
+++ b/lib/sus/context.rb
@@ -75,5 +75,41 @@ module Sus
 				end
 			end
 		end
+		
+		def before(&block)
+			wrapper = Module.new
+			
+			wrapper.define_method(:before) do
+				super()
+				instance_exec(&block)
+			end
+			
+			self.include(wrapper)
+		end
+		
+		def after(&block)
+			wrapper = Module.new
+			
+			wrapper.define_method(:after) do
+				instance_exec(&block)
+				super()
+			end
+			
+			self.include(wrapper)
+		end
+		
+		def around(&block)
+			wrapper = Module.new
+			
+			wrapper.define_method(:around) do
+				call_super = proc do
+					super()
+				end
+				
+				instance_exec(call_super, &block)
+			end
+			
+			self.include(wrapper)
+		end
 	end
 end

--- a/lib/sus/include_context.rb
+++ b/lib/sus/include_context.rb
@@ -7,8 +7,8 @@ require_relative 'context'
 
 module Sus
 	module Context
-		def include_context(shared, ...)
-			shared.included(self, ...)
+		def include_context(shared, *arguments, **options)
+			self.class_exec(*arguments, **options, &shared.block)
 		end
 	end
 end

--- a/lib/sus/include_context.rb
+++ b/lib/sus/include_context.rb
@@ -6,45 +6,7 @@
 require_relative 'context'
 
 module Sus
-	module IncludeContext
-		module Helpers
-			def prepend(*arguments, &block)
-				arguments.each do |argument|
-					if argument.class == Module
-						super(argument)
-					else
-						argument.prepended(self)
-					end
-				end
-
-				if block_given?
-					wrapper = Module.new
-					wrapper.instance_exec(&block)
-					super(wrapper)
-				end
-			end
-			
-			def include(*arguments, &block)
-				arguments.each do |argument|
-					if argument.class == Module
-						super(argument)
-					else
-						argument.included(self)
-					end
-				end
-				
-				if block_given?
-					wrapper = Module.new
-					wrapper.module_exec(&block)
-					super(wrapper)
-				end
-			end
-		end
-	end
-	
 	module Context
-		include IncludeContext::Helpers
-		
 		def include_context(shared, ...)
 			shared.included(self, ...)
 		end

--- a/lib/sus/include_context.rb
+++ b/lib/sus/include_context.rb
@@ -6,9 +6,47 @@
 require_relative 'context'
 
 module Sus
+	module IncludeContext
+		module Helpers
+			def prepend(*arguments, &block)
+				arguments.each do |argument|
+					if argument.class == Module
+						super(argument)
+					else
+						argument.prepended(self)
+					end
+				end
+
+				if block_given?
+					wrapper = Module.new
+					wrapper.instance_exec(&block)
+					super(wrapper)
+				end
+			end
+			
+			def include(*arguments, &block)
+				arguments.each do |argument|
+					if argument.class == Module
+						super(argument)
+					else
+						argument.included(self)
+					end
+				end
+				
+				if block_given?
+					wrapper = Module.new
+					wrapper.module_exec(&block)
+					super(wrapper)
+				end
+			end
+		end
+	end
+	
 	module Context
-		def include_context(shared, *arguments, **options)
-			self.class_exec(*arguments, **options, &shared.block)
+		include IncludeContext::Helpers
+		
+		def include_context(shared, ...)
+			shared.included(self, ...)
 		end
 	end
 end

--- a/lib/sus/it_behaves_like.rb
+++ b/lib/sus/it_behaves_like.rb
@@ -18,12 +18,12 @@ module Sus
 			base.description = shared.name
 			base.identity = Identity.nested(parent.identity, base.description, unique: unique)
 			base.set_temporary_name("#{self}[#{base.description}]")
-
+			
 			# User provided block is evaluated first, so that it can provide default behaviour for the shared context:
 			if block_given?
 				base.class_exec(*arguments, &block)
 			end
-
+			
 			base.class_exec(*arguments, &shared.block)
 			return base
 		end

--- a/lib/sus/shared.rb
+++ b/lib/sus/shared.rb
@@ -18,6 +18,10 @@ module Sus
 			
 			return base
 		end
+		
+		def included(base, *arguments, **options)
+			base.class_exec(*arguments, **options, &self.block)
+		end
 	end
 	
 	def self.Shared(name, &block)

--- a/lib/sus/shared.rb
+++ b/lib/sus/shared.rb
@@ -11,7 +11,7 @@ module Sus
 		attr_accessor :block
 		
 		def self.build(name, block)
-			base = Class.new
+			base = Module.new
 			base.extend(Shared)
 			base.name = name
 			base.block = block
@@ -19,8 +19,12 @@ module Sus
 			return base
 		end
 		
-		def included(base, *arguments, **options)
-			base.class_exec(*arguments, **options, &self.block)
+		def included(base)
+			base.class_exec(&self.block)
+		end
+		
+		def prepended(base)
+			base.class_exec(&self.block)
 		end
 	end
 	

--- a/test/sus/include_context.rb
+++ b/test/sus/include_context.rb
@@ -5,15 +5,31 @@
 
 AThing = Sus::Shared("a thing") do |key, value: 42|
 	let(:a_thing) {{key => value}}
+	
+	include do
+		def before
+			super
+			
+			events << :shared_before
+		end
+	end
 end
 
 describe Sus::Context do
 	with '.include_context' do
 		with "a shared context with an option" do
+			let(:events) {Array.new}
 			include_context AThing, :key, value: 42
+			
+			def before
+				super
+				
+				events << :example_before
+			end
 			
 			it "can include a shared context" do
 				expect(a_thing).to be == {:key => 42}
+				expect(events).to be == [:shared_before, :example_before]
 			end
 		end
 	end

--- a/test/sus/include_context.rb
+++ b/test/sus/include_context.rb
@@ -3,38 +3,46 @@
 # Released under the MIT License.
 # Copyright, 2023, by Samuel Williams.
 
-AThing = Sus::Shared("a thing") do |key, value: 42|
+AContextWithArguments = Sus::Shared("a context with arguments") do |key, value: 42|
 	let(:a_thing) {{key => value}}
-	
+end
+
+AContextWithHooks = Sus::Shared("a context with hooks") do
 	before do
-		$stderr.puts "before: #{self}"
 		events << :shared_before
 	end
 	
 	after do
-		$stderr.puts "after: #{self}"
 		events << :shared_after
 	end
 	
-	around do |block|
-		$stderr.puts "around: #{self}"
-		block.call
+	around do |&block|
+		events << :shared_around_before
+		super(&block)
 	end
 end
 
 describe Sus::Context do
 	with '.include_context' do
 		with "a shared context with an option" do
+			include_context AContextWithArguments, :key, value: 42
+			
+			it "can include a shared context with arguments" do
+				expect(a_thing).to be == {:key => 42}
+			end
+		end
+		
+		with "a shared context with arguments" do
 			let(:events) {Array.new}
-			include_context AThing, :key, value: 42
+			
+			include AContextWithHooks
 			
 			before do
 				events << :example_before
 			end
 			
 			it "can include a shared context" do
-				expect(a_thing).to be == {:key => 42}
-				expect(events).to be == [:shared_before, :example_before]
+				expect(events).to be == [:example_before, :shared_around_before, :shared_before]
 			end
 		end
 	end

--- a/test/sus/include_context.rb
+++ b/test/sus/include_context.rb
@@ -6,12 +6,19 @@
 AThing = Sus::Shared("a thing") do |key, value: 42|
 	let(:a_thing) {{key => value}}
 	
-	include do
-		def before
-			super
-			
-			events << :shared_before
-		end
+	before do
+		$stderr.puts "before: #{self}"
+		events << :shared_before
+	end
+	
+	after do
+		$stderr.puts "after: #{self}"
+		events << :shared_after
+	end
+	
+	around do |block|
+		$stderr.puts "around: #{self}"
+		block.call
 	end
 end
 
@@ -21,9 +28,7 @@ describe Sus::Context do
 			let(:events) {Array.new}
 			include_context AThing, :key, value: 42
 			
-			def before
-				super
-				
+			before do
 				events << :example_before
 			end
 			


### PR DESCRIPTION
After some practical usage, I found the design of the before, after and around hooks to be a little counter-intuitive.

- `def before` in a shared context can clobber existing before hooks.
- `before` and `after` hooks are all run from bottom to top, and *then* `around` hooks. This leads to odd interleaving of hooks, in other words, an `around` hook is not equivalent to `before` and `after` hooks.

We introduce a better model for before and after hooks, and a better model for including shared contexts.