### PR TITLE
Suppress laudatory summary output when no assertions are executed.

### DIFF
--- a/lib/sus/config.rb
+++ b/lib/sus/config.rb
@@ -168,11 +168,14 @@ module Sus
 			
 			print_finished_statistics(output, assertions)
 			
-			if !partial? and assertions.passed?
-				print_test_feedback(output, assertions)
+			unless assertions.count.zero?
+				if !partial? and assertions.passed?
+					print_test_feedback(output, assertions)
+				end
+				
+				print_slow_tests(output, assertions)
 			end
 			
-			print_slow_tests(output, assertions)
 			print_failed_assertions(output, assertions)
 		end
 		
@@ -181,9 +184,13 @@ module Sus
 		# @parameter assertions [Assertions] The assertions instance.
 		def print_finished_statistics(output, assertions)
 			duration = @clock.duration
-			rate = assertions.count / duration
 			
-			output.puts "🏁 Finished in ", @clock, "; #{rate.round(3)} assertions per second."
+			if assertions.count.zero?
+				output.puts "🏴 Finished in ", @clock, "."
+			else
+				rate = assertions.count / duration
+				output.puts "🏁 Finished in ", @clock, "; #{rate.round(3)} assertions per second."
+			end
 		end
 		
 		# Print feedback about the test suite.

--- a/test/sus/config.rb
+++ b/test/sus/config.rb
@@ -5,6 +5,12 @@
 
 require "fixtures"
 
+class Target
+	def print(output)
+		output.write("target")
+	end
+end
+
 describe Sus::Config do
 	include Fixtures
 	
@@ -13,5 +19,52 @@ describe Sus::Config do
 	
 	it "can load config from file" do
 		expect(config).not.to be(:nil?)
+	end
+	
+	with "summary output" do
+		let(:io) {StringIO.new}
+		let(:output) {Sus::Output::Text.new(io)}
+		let(:assertions) {Sus::Assertions.new(output: Sus::Output.buffered)}
+		
+		with "errors and no assertions" do
+			it "suppresses laudatory output but prints timing" do
+				assertions.nested(Target.new, isolated: true) do |nested|
+					nested.error!(RuntimeError.new("load error"))
+				end
+				
+				config.before_tests(assertions, output: output)
+				config.after_tests(assertions, output: output)
+				
+				expect(io.string).to be(:include?, "🏴 Finished in")
+				expect(io.string).not.to be(:include?, "assertions per second")
+				expect(io.string).not.to be(:include?, "No slow tests found")
+				expect(io.string).to be(:include?, "Errored assertions")
+			end
+		end
+		
+		with "no assertions and no errors" do
+			it "suppresses laudatory output but prints timing" do
+				config.before_tests(assertions, output: output)
+				config.after_tests(assertions, output: output)
+				
+				expect(io.string).to be(:include?, "🏴 Finished in")
+				expect(io.string).not.to be(:include?, "assertions per second")
+				expect(io.string).not.to be(:include?, "No slow tests found")
+			end
+		end
+		
+		with "passing assertions" do
+			it "prints statistics and slow test output" do
+				assertions.nested(Target.new, isolated: true, measure: true) do |nested|
+					nested.assert(true)
+				end
+				
+				config.before_tests(assertions, output: output)
+				config.after_tests(assertions, output: output)
+				
+				expect(io.string).to be(:include?, "Finished in")
+				expect(io.string).to be(:include?, "No slow tests found")
+			end
+		end
 	end
 end


### PR DESCRIPTION
Suggest to drop the "checkered flag" & rabbit emoji when no tests run.

This patch swaps in "black flag" for this case. I would have chosen "white flag" but that doesn't align well due to rendering issues in macOS.

Any desired changes are OK with me.

### Before

#### With errors

```
0 assertions
🏁 Finished in 26.0µs; 0.0 assertions per second.
🐇 No slow tests found! Well done!

🔥 Errored assertions:
file test/example.rb:1
   ⚠ LoadError: cannot load such file -- test_helper
```

### After

#### With errors

```
0 assertions
🏴 Finished in 32.0µs.

🔥 Errored assertions:
file test/example.rb:1
   ⚠ LoadError: cannot load such file -- test_helper
```

#### No errors

```
0 assertions
🏴 Finished in 450.0µs.
```

## Types of Changes

- New feature.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
