### PR TITLE
Prefer `XTerm` output on GitHub actions. Fixes #47.

### DIFF
--- a/lib/sus/output.rb
+++ b/lib/sus/output.rb
@@ -13,11 +13,19 @@ require_relative "output/progress"
 module Sus
 	# Represents output handlers for test results and messages.
 	module Output
+		# Detect if we're running in GitHub Actions, where human-readable output is preferred.
+		# GitHub Actions sets the GITHUB_ACTIONS environment variable to "true".
+		# @parameter env [Hash] The environment variables to check.
+		def self.github_actions?(env)
+			env["GITHUB_ACTIONS"] == "true"
+		end
+		
 		# Create an appropriate output handler for the given IO.
 		# @parameter io [IO] The IO object to write to.
-		# @returns [XTerm, Text] An XTerm handler if the IO is a TTY, otherwise a Text handler.
-		def self.for(io)
-			if io.isatty
+		# @parameter env [Hash] The environment variables to consider (defaults to ENV).
+		# @returns [XTerm, Text] An XTerm handler if the IO is a TTY or running in GitHub Actions, otherwise a Text handler.
+		def self.for(io, env = ENV)
+			if io.isatty or self.github_actions?(env)
 				XTerm.new(io)
 			else
 				Text.new(io)
@@ -26,9 +34,10 @@ module Sus
 		
 		# Create a default output handler with styling configured.
 		# @parameter io [IO] The IO object to write to (defaults to $stderr).
+		# @parameter env [Hash] The environment variables to consider (defaults to ENV).
 		# @returns [XTerm, Text] A configured output handler.
-		def self.default(io = $stderr)
-			output = self.for(io)
+		def self.default(io = $stderr, env = ENV)
+			output = self.for(io, env)
 			
 			Output::Bar.register(output)
 			

--- a/lib/sus/output/status.rb
+++ b/lib/sus/output/status.rb
@@ -11,7 +11,7 @@ module Sus
 			# @parameter output [Output] The output handler to register with.
 			def self.register(output)
 				output[:free] ||= output.style(:blue)
-				output[:busy] ||= output.style(:orange)
+				output[:busy] ||= output.style(:red)
 			end
 			
 			# Initialize a new Status indicator.

--- a/test/sus/output/status.rb
+++ b/test/sus/output/status.rb
@@ -7,7 +7,7 @@ require "sus/output/status"
 
 describe Sus::Output::Status do
 	let(:buffer) {StringIO.new}
-	let(:output) {Sus::Output.for(buffer)}
+	let(:output) {Sus::Output.for(buffer, {})}
 	
 	def before
 		Sus::Output::Status.register(output)


### PR DESCRIPTION
The fact we have to do this is a testament to the design of GitHub Actions.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
