### PR TITLE
Improve mock block handling

### DIFF
--- a/lib/sus/mock.rb
+++ b/lib/sus/mock.rb
@@ -90,8 +90,8 @@ module Sus
 			
 			@interceptor.define_method(method) do |*arguments, **options, &block|
 				if execution_context == Thread.current
-					original = proc do |*arguments, **options|
-						super(*arguments, **options)
+					original = proc do |*arguments, **options, &block|
+						super(*arguments, **options, &block)
 					end
 					
 					hook.call(original, *arguments, **options, &block) 

--- a/lib/sus/receive.rb
+++ b/lib/sus/receive.rb
@@ -239,8 +239,7 @@ module Sus
 			# @parameter subject [Proc, nil] The block to check.
 			def call(assertions, subject)
 				assertions.nested(self) do |assertions|
-					
-					Expect.new(assertions, subject).not.to(Be == nil)
+					Expect.new(assertions, subject).to(@predicate)
 				end
 			end
 		end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Fixed `Sus::Mock#wrap` to forward blocks to the original method, and fixed `receive(...).with_block(...)` to use the supplied predicate.
+
 ## v0.37.0
 
   - Long values in verbose (and failure) output are now truncated to a configurable length (default 100 characters), preventing huge objects from flooding the output. Set the `SUS_OUTPUT_VARIABLE_TRUNCATION_LIMIT` environment variable to change the limit, or `0` to disable truncation.

--- a/test/sus/mock.rb
+++ b/test/sus/mock.rb
@@ -25,6 +25,10 @@ class Interface
 	def implementation(*arguments)
 		RealImplementation.new
 	end
+	
+	def call
+		yield
+	end
 end
 
 describe Sus::Mock do
@@ -129,6 +133,16 @@ describe Sus::Mock do
 		it "can wrap a method" do
 			interface = RealImplementation.new(10)
 			expect(interface.value).to be == 20
+		end
+		
+		it "can call the original method with a block" do
+			mock(interface) do |mock|
+				mock.wrap(:call) do |original, &block|
+					original.call(&block)
+				end
+			end
+			
+			expect(interface.call{"Hello World"}).to be == "Hello World"
 		end
 	end
 end

--- a/test/sus/receive.rb
+++ b/test/sus/receive.rb
@@ -19,6 +19,10 @@ class Interface
 	def implementation(*arguments, **options)
 		RealImplementation.new
 	end
+	
+	def call
+		yield
+	end
 end
 
 describe Sus::Receive do
@@ -76,6 +80,12 @@ describe Sus::Receive do
 		expect(interface).to receive(:implementation).with(x: 1, y: 2)
 		
 		interface.implementation(x: 1, y: 2)
+	end
+	
+	it "can validate a block" do
+		expect(interface).to receive(:call).with_block(be(:lambda?))
+		
+		interface.call(&->{})
 	end
 	
 	describe Sus::Receive::Times do


### PR DESCRIPTION
## Summary

- Forward blocks through `Sus::Mock#wrap` when calling the original method.
- Make `receive(...).with_block(...)` evaluate the supplied predicate instead of only checking for a non-nil block.
- Add regression coverage for both behaviours and an unreleased note.

## Testing

- `/nix/store/jh918yiwd5cs4pjg005ac32m2q7ckw3l-ruby-4.0.5/bin/ruby -Ilib bin/sus`