### PR TITLE
Improve test coverage.

### DIFF
--- a/.github/workflows/documentation-coverage.yaml
+++ b/.github/workflows/documentation-coverage.yaml
@@ -6,6 +6,7 @@ permissions:
   contents: read
 
 env:
+  BUNDLE_WITH: maintenance
   COVERAGE: PartialSummary
 
 jobs:

--- a/fixtures/sus/bin/failing.rb
+++ b/fixtures/sus/bin/failing.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+describe "failing executable fixture" do
+	it "fails" do
+		assert(false)
+	end
+end

--- a/fixtures/sus/bin/passing.rb
+++ b/fixtures/sus/bin/passing.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+describe "passing executable fixture" do
+	it "passes" do
+		assert(true)
+	end
+end

--- a/fixtures/sus/file/error.rb
+++ b/fixtures/sus/file/error.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+raise "load failed"

--- a/fixtures/sus/file/syntax_error.sus
+++ b/fixtures/sus/file/syntax_error.sus
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+if true

--- a/gems.rb
+++ b/gems.rb
@@ -15,11 +15,11 @@ group :maintenance, optional: true do
 	gem "agent-context"
 	
 	gem "utopia-project"
+	gem "decode", platforms: :mri
 end
 
 group :test do
 	gem "covered"
-	gem "decode"
 	
 	gem "rubocop"
 	gem "rubocop-md"

--- a/lib/sus/be.rb
+++ b/lib/sus/be.rb
@@ -46,7 +46,7 @@ module Sus
 			# @parameter other [Object] Another predicate to combine.
 			# @returns [Or] A new OR predicate.
 			def |(other)
-				Or.new(self, other)
+				Or.new([self, other])
 			end
 		end
 		
@@ -93,7 +93,7 @@ module Sus
 			# @parameter other [Object] Another predicate to combine.
 			# @returns [And] A new AND predicate.
 			def &(other)
-				And.new(self, other)
+				And.new([self, other])
 			end
 			
 			# Combine this predicate with another using OR logic.

--- a/lib/sus/config.rb
+++ b/lib/sus/config.rb
@@ -196,13 +196,16 @@ module Sus
 		
 		# Print feedback about the test suite.
 		# @parameter output [Output] The output handler.
-		# @parameter assertions [Assertions] The assertions instance.
-		def print_test_feedback(output, assertions)
-			duration = @clock.duration
-			rate = assertions.count / duration
-			
-			total = assertions.total
-			count = assertions.count
+		# @parameter assertions [Assertions | Nil] The assertions instance.
+		# @parameter duration [Float] The total duration of the test suite.
+		# @parameter count [Integer] The number of assertions.
+		# @parameter total [Integer] The number of tests.
+		def print_test_feedback(output, assertions = nil,
+			duration: @clock.duration,
+			count: assertions.count,
+			total: assertions.total
+		)
+			rate = count / duration
 			
 			if total < 10 or count < 10
 				output.puts "😭 You should write more tests and assertions!"
@@ -212,7 +215,7 @@ module Sus
 			end
 			
 			# Check whether there is at least, on average, one assertion (or more) per test:
-			assertions_per_test = assertions.count / assertions.total
+			assertions_per_test = count / total
 			if assertions_per_test < 1.0
 				output.puts "😩 Your tests don't have enough assertions (#{assertions_per_test.round(1)} < 1.0)!"
 			end
@@ -241,6 +244,8 @@ module Sus
 				output.puts "🔥 Wow! Your test suite has outstanding performance (#{rate.round(1)} >= 10000.0)!"
 			end
 		end
+		
+		public :print_test_feedback
 		
 		# Print information about slow tests.
 		# @parameter output [Output] The output handler.

--- a/lib/sus/context.rb
+++ b/lib/sus/context.rb
@@ -24,28 +24,6 @@ module Sus
 			base.children = Hash.new
 		end
 		
-		unless respond_to?(:set_temporary_name)
-			# Set a temporary name for this context.
-			# @parameter name [String] The temporary name.
-			def set_temporary_name(name)
-				# No-op.
-			end
-			
-			# @returns [String] A string representation of this context.
-			def to_s
-				(self.description || self.name).to_s
-			end
-			
-			# @returns [String] An inspect representation of this context.
-			def inspect
-				if description = self.description
-					"\#<#{self.name || "Context"} #{self.description}>"
-				else
-					self.name
-				end
-			end
-		end
-		
 		# Add a child context or test to this context.
 		# @parameter child [Object] The child to add.
 		def add(child)

--- a/lib/sus/identity.rb
+++ b/lib/sus/identity.rb
@@ -142,7 +142,7 @@ module Sus
 				end
 			else
 				# In theory this should be a bit faster:
-				each_caller_location do |location|
+				Thread.each_caller_location do |location|
 					if location.path == @path
 						return self.with_line(location.lineno)
 					end
@@ -153,16 +153,6 @@ module Sus
 		end
 		
 		protected
-		
-		if Thread.respond_to?(:each_caller_location)
-			def each_caller_location(&block)
-				Thread.each_caller_location(&block)
-			end
-		else
-			def each_caller_location(&block)
-				caller_locations(1).each(&block)
-			end
-		end
 		
 		def append_unique_key(key, unique = @unique)
 			if @parent

--- a/lib/sus/respond_to.rb
+++ b/lib/sus/respond_to.rb
@@ -21,9 +21,9 @@ module Sus
 				parameters = @parameters.dup
 				
 				assertions.nested(self) do |assertions|
-					expected_name = parameters.shift
-					
 					subject.each do |type, name|
+						expected_name = parameters.shift
+						
 						case type
 						when :req
 							assertions.assert(name == expected_name, "parameter #{expected_name} is required, but was #{name}")

--- a/test/sus/assertions.rb
+++ b/test/sus/assertions.rb
@@ -53,6 +53,31 @@ describe Sus::Assertions do
 				string: be =~ /Hello world/
 			)
 		end
+		
+		it "can add informational output from a block" do
+			assertions.inform do
+				"Hello block"
+			end
+			
+			expect(assertions.output).to have_attributes(
+				string: be =~ /Hello block/
+			)
+		end
+		
+		it "can add informational output from a failing block" do
+			assertions.inform do
+				raise "Boom"
+			end
+			
+			expect(assertions.output).to have_attributes(
+				string: be =~ /Boom/
+			)
+		end
+		
+		it "can report its message and emptiness" do
+			expect(assertions.empty?).to be == true
+			expect(assertions.message).to be(:include?, :text)
+		end
 	end
 	
 	# Inverted assertions mean that we are passing if at least one assertion fails!
@@ -94,6 +119,65 @@ describe Sus::Assertions do
 			expect(assertions.passed.size).to be == 4
 			expect(assertions.count).to be == 4
 		end
+	end
+	
+	with "printing" do
+		let(:output) {Sus::Output.buffered}
+		
+		it "prints verbose target output" do
+			assertions = Sus::Assertions.new(target: Nested.new("target"), output: Sus::Output.buffered, verbose: true)
+			assertions.assert(true)
+			assertions.print(output)
+			
+			expect(output.string).to be(:include?, "nested target")
+		end
+		
+		it "prints deferred, skipped and errored counts" do
+			assertions.assert(true)
+			assertions.defer{}
+			assertions.skip("skip")
+			assertions.error!(RuntimeError.new("boom"))
+			assertions.print(output)
+			
+			expect(output.string).to be(:include?, "deferred")
+			expect(output.string).to be(:include?, "skipped")
+			expect(output.string).to be(:include?, "errored")
+		end
+	end
+	
+	with "failures" do
+		it "can enumerate failed assertions" do
+			assertions.assert(false)
+			
+			failures = assertions.each_failure.to_a
+			
+			expect(failures).to have_attributes(size: be == 1)
+			expect(failures.first.message).to be(:include?, :text)
+		end
+		
+		it "can enumerate errored assertions" do
+			assertions.error!(RuntimeError.new("boom"))
+			
+			failures = assertions.each_failure.to_a
+			
+			expect(failures).to have_attributes(size: be == 1)
+			expect(failures.first.message[:text]).to be(:include?, "boom")
+		end
+		
+		it "can treat failed assertions as distinct" do
+			assertions = Sus::Assertions.new(output: Sus::Output.buffered, distinct: true)
+			assertions.assert(false)
+			
+			failures = assertions.each_failure.to_a
+			
+			expect(failures).to be == [assertions]
+		end
+	end
+	
+	it "can write directly to its output" do
+		assertions.puts("hello")
+		
+		expect(assertions.output.string).to be(:include?, "hello")
 	end
 	
 	with "deferred assertions" do

--- a/test/sus/base.rb
+++ b/test/sus/base.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+describe Sus::Base do
+	let(:assertions) {Sus::Assertions.new(output: Sus::Output.buffered)}
+	
+	it "can inspect itself" do
+		base = Sus.base("example")
+		instance = base.new(assertions)
+		
+		expect(instance.inspect).to be == "#<Sus::Base for \"example\">"
+	end
+	
+	it "runs after hooks when the block raises" do
+		instance = subject.new(assertions)
+		
+		begin
+			instance.around do
+				raise "boom"
+			end
+		rescue RuntimeError => error
+			expect(error.message).to be == "boom"
+		end
+	end
+	
+	it "can inform through assertions" do
+		instance = subject.new(assertions)
+		instance.inform("hello")
+		
+		expect(assertions.output.string).to be(:include?, "hello")
+	end
+end

--- a/test/sus/be.rb
+++ b/test/sus/be.rb
@@ -4,7 +4,17 @@
 # Copyright, 2021-2024, by Samuel Williams.
 
 describe Sus::Be do
+	def render(predicate)
+		buffer = Sus::Output::Buffered.new
+		predicate.print(buffer)
+		return buffer.string
+	end
+	
 	with "true" do
+		it "can print truthy" do
+			expect(render(be_truthy)).to be == "be truthy"
+		end
+		
 		it "can expect equality" do
 			expect(true).to be == true
 		end
@@ -23,6 +33,10 @@ describe Sus::Be do
 	end
 	
 	with "false" do
+		it "can print falsey" do
+			expect(render(be_falsey)).to be == "be falsey"
+		end
+		
 		it "can expect equality" do
 			expect(false).to be == false
 		end
@@ -93,6 +107,10 @@ describe Sus::Be do
 	end
 	
 	describe Sus::Be::And do
+		it "can print" do
+			expect(render((be > 5) & (be < 20))).to be == "be > 5 and be < 20"
+		end
+		
 		it "can combine two predicates" do
 			expect(10).to (be > 5) & (be < 20)
 		end
@@ -112,9 +130,17 @@ describe Sus::Be do
 			
 			expect(assertions).to be(:failed?)
 		end
+		
+		it "can combine with or" do
+			expect(10).to ((be > 20) & (be < 30)) | (be == 10)
+		end
 	end
 	
 	describe Sus::Be::Or do
+		it "can print" do
+			expect(render((be > 5) | (be < 20))).to be == "be > 5 or be < 20"
+		end
+		
 		it "can combine two predicates" do
 			expect(10).to (be > 5) | (be < 5)
 		end
@@ -137,6 +163,10 @@ describe Sus::Be do
 			Sus::Expect.new(assertions, 10).to (be > 10) | (be < 5) | (be == 15) | (be == 20)
 			
 			expect(assertions).to be(:failed?)
+		end
+		
+		it "can combine with and" do
+			expect(10).to ((be > 5) | (be < 5)) & (be == 10)
 		end
 	end
 end

--- a/test/sus/be_within.rb
+++ b/test/sus/be_within.rb
@@ -4,6 +4,16 @@
 # Copyright, 2021-2024, by Samuel Williams.
 
 describe Sus::BeWithin do
+	def render(predicate)
+		buffer = Sus::Output::Buffered.new
+		predicate.print(buffer)
+		return buffer.string
+	end
+	
+	it "can print" do
+		expect(render(be_within(10))).to be == "be within 10"
+	end
+	
 	it "can expect number to be within a tolerance" do
 		expect(0).to be_within(10)
 		expect(5).to be_within(10)
@@ -19,6 +29,10 @@ describe Sus::BeWithin do
 	end
 	
 	with Range do
+		it "can print" do
+			expect(render(be_within(2..7))).to be == "be within 2..7"
+		end
+		
 		it "can expect number to be within a range" do
 			expect(5).to be_within(2..7)
 			expect(2).to be_within(2..7)

--- a/test/sus/bin.rb
+++ b/test/sus/bin.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "open3"
+require "rbconfig"
+
+describe "bin/sus" do
+	def run_sus(*arguments)
+		Open3.capture3(
+			{
+				"RUBYOPT" => ENV["RUBYOPT"],
+			},
+			RbConfig.ruby,
+			"bin/sus",
+			*arguments,
+			chdir: File.expand_path("../..", __dir__)
+		)
+	end
+	
+	it "can run passing tests quietly" do
+		output, error, status = run_sus("fixtures/sus/bin/passing.rb")
+		
+		expect(status).to be(:success?)
+		expect(output).to be == ""
+	end
+	
+	it "can run passing tests verbosely" do
+		output, error, status = run_sus("--verbose", "fixtures/sus/bin/passing.rb")
+		
+		expect(status).to be(:success?)
+		expect(output + error).to be(:include?, "1 passed")
+	end
+	
+	it "exits unsuccessfully when tests fail" do
+		output, error, status = run_sus("fixtures/sus/bin/failing.rb")
+		
+		expect(status).not.to be(:success?)
+		expect(output).to be == ""
+	end
+end

--- a/test/sus/clock.rb
+++ b/test/sus/clock.rb
@@ -30,6 +30,10 @@ describe Sus::Clock do
 		expect(Sus::Clock.new(1.123).to_f).to be == 1.123
 	end
 	
+	it "can convert to milliseconds" do
+		expect(Sus::Clock.new(1.123).ms).to be == 1123.0
+	end
+	
 	it "can be compared" do
 		expect(Sus::Clock.new(1.123) <=> Sus::Clock.new(1.123)).to be == 0
 		expect(Sus::Clock.new(1.123) <=> Sus::Clock.new(1.124)).to be == -1

--- a/test/sus/config.rb
+++ b/test/sus/config.rb
@@ -68,4 +68,49 @@ describe Sus::Config do
 			end
 		end
 	end
+	
+	with "test feedback" do
+		let(:io) {StringIO.new}
+		let(:output) {Sus::Output::Text.new(io)}
+		
+		def print_test_feedback(count, total, duration)
+			config.print_test_feedback(output, count: count, total: total, duration: duration)
+			io.string
+		end
+		
+		it "reports too few assertions and slow performance" do
+			output = print_test_feedback(10, 15, 2.0)
+			
+			expect(output).to be(:include?, "don't have enough assertions")
+			expect(output).to be(:include?, "write more tests")
+			expect(output).to be(:include?, "performance is painful")
+		end
+		
+		it "reports an early test suite and poor performance" do
+			output = print_test_feedback(20, 20, 1.0)
+			
+			expect(output).to be(:include?, "starting to shape up")
+			expect(output).to be(:include?, "could be better")
+		end
+		
+		it "reports a maturing test suite and good performance" do
+			output = print_test_feedback(60, 60, 0.1)
+			
+			expect(output).to be(:include?, "maturing")
+			expect(output).to be(:include?, "good performance")
+		end
+		
+		it "reports amazing test suite and excellent performance" do
+			output = print_test_feedback(100, 100, 0.05)
+			
+			expect(output).to be(:include?, "amazing")
+			expect(output).to be(:include?, "excellent performance")
+		end
+		
+		it "reports outstanding performance" do
+			output = print_test_feedback(10_000, 10_000, 1.0)
+			
+			expect(output).to be(:include?, "outstanding performance")
+		end
+	end
 end

--- a/test/sus/context.rb
+++ b/test/sus/context.rb
@@ -28,6 +28,23 @@ describe Sus::Describe do
 		expect(instance.full_name).to be == "describe test"
 	end
 	
+	it "can inspect and enumerate children" do
+		instance.it("leaf"){}
+		children = []
+		instance.each{|child| children << child}
+		
+		expect(instance.to_s).to be(:include?, "test")
+		expect(instance.inspect).to be(:include?, "test")
+		expect(children).to have_attributes(size: be == 1)
+	end
+	
+	it "can inspect without a description" do
+		base = Sus.base
+		
+		expect(base.to_s).to be == base.name.to_s
+		expect(base.inspect).to be == base.name
+	end
+	
 	with "before hooks" do
 		let(:events) {Array.new}
 		
@@ -58,6 +75,23 @@ describe Sus::Describe do
 		
 		it "invokes after hooks" do
 			events << :example
+		end
+		
+		it "still invokes after hooks when they raise" do
+			events << :example
+			
+			context = Sus::Describe.build(Sus.base, "raises")
+			context.after do
+				raise "after failed"
+			end
+			test = context.it("test"){}
+			instance = test.new(Sus::Assertions.new)
+			
+			begin
+				instance.after(nil)
+			rescue RuntimeError => error
+				expect(error.message).to be == "after failed"
+			end
 		end
 	end
 end

--- a/test/sus/describe.rb
+++ b/test/sus/describe.rb
@@ -16,7 +16,7 @@ describe Sus::Describe do
 		it "can print context name" do
 			buffer = Sus::Output.buffered
 			context.print(buffer)
-			expect(buffer.string).to be =~ %r{describe a test class}
+			expect(buffer.string).to be =~ %r{a test class}
 		end
 	end
 	

--- a/test/sus/expect.rb
+++ b/test/sus/expect.rb
@@ -4,6 +4,8 @@
 # Copyright, 2022-2024, by Samuel Williams.
 
 describe Sus::Expect do
+	let(:assertions) {Sus::Assertions.new(output: Sus::Output.buffered)}
+	
 	with "a hash table" do
 		let(:target) {Hash.new}
 		
@@ -17,9 +19,25 @@ describe Sus::Expect do
 		end
 	end
 	
+	it "can print inverted expectations" do
+		expectation = Sus::Expect.new(assertions, "value").not
+		buffer = Sus::Output::Buffered.new
+		
+		expectation.print(buffer)
+		
+		expect(buffer.string).to be == "expect \"value\" not to"
+	end
+	
+	it "can chain expectations with and" do
+		expectation = Sus::Expect.new(assertions, "value")
+		
+		expectation.and(be == "value")
+		
+		expect(assertions.count).to be == 1
+	end
+	
 	with "exceptions" do
 		let(:identity) {Sus::Identity.new(__FILE__)}
-		let(:assertions) {Sus::Assertions.new(identity: identity)}
 		let(:expectation) {Sus::Expect.new(assertions, Object.new)}
 		
 		it "is expected to propagate errors" do

--- a/test/sus/file.rb
+++ b/test/sus/file.rb
@@ -11,4 +11,42 @@ describe Sus::File do
 		
 		expect(FILE.name).to be == "Sus::File[#{__FILE__}]"
 	end
+	
+	it "can load a file using []" do
+		file = subject[__FILE__]
+		
+		expect(file.description).to be == __FILE__
+	end
+	
+	it "captures file load errors" do
+		path = File.expand_path("../../fixtures/sus/file/error.rb", __dir__)
+		file = subject.build(Sus.base, path)
+		child = file.children.values.first
+		
+		expect(child).to be(:leaf?)
+		expect(child.children).to be(:empty?)
+		expect(child.description).to be == path
+		
+		output = Sus::Output.buffered
+		child.print(output)
+		expect(output.string).to be(:include?, "file")
+		
+		assertions = Sus::Assertions.new(output: Sus::Output.buffered)
+		child.call(assertions)
+		expect(assertions.errored).not.to be(:empty?)
+	end
+	
+	it "captures syntax errors with line numbers" do
+		path = File.expand_path("../../fixtures/sus/file/syntax_error.sus", __dir__)
+		file = subject.build(Sus.base, path)
+		child = file.children.values.first
+		
+		expect(child.identity.line).to be == 3
+	end
+	
+	it "can extract line numbers from syntax errors" do
+		error = SyntaxError.new("example.rb:123: syntax error")
+		
+		expect(error.lineno).to be == 123
+	end
 end

--- a/test/sus/filter.rb
+++ b/test/sus/filter.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+describe Sus::Filter do
+	FakeIdentity = Struct.new(:key)
+	
+	class FakeRegistry
+		def initialize(child)
+			@child = child
+			@loaded = []
+			@called = false
+		end
+		
+		attr :loaded
+		attr :called
+		
+		def children
+			{FakeIdentity.new("test.rb:1") => @child}
+		end
+		
+		def load(path)
+			@loaded << path
+		end
+		
+		def each
+			yield @child
+		end
+		
+		def call(assertions)
+			@called = true
+		end
+	end
+	
+	let(:child) {Sus::It.build(Sus.base, "child"){assert(true)}}
+	let(:registry) {FakeRegistry.new(child)}
+	let(:filter) {subject.new(registry)}
+	
+	it "delegates to the registry without a filter" do
+		filter.load("test.rb")
+		
+		collected = []
+		filter.each{|item| collected << item}
+		filter.call(Sus::Assertions.new)
+		
+		expect(registry.loaded).to be == ["test.rb"]
+		expect(collected).to be == [child]
+		expect(registry.called).to be == true
+	end
+	
+	it "filters by identity key" do
+		filter.load("test.rb:1")
+		
+		collected = []
+		filter.each{|item| collected << item}
+		
+		assertions = filter.call(Sus::Assertions.new)
+		
+		expect(registry.loaded).to be == ["test.rb"]
+		expect(collected).to be == [child]
+		expect(assertions.count).to be == 1
+	end
+	
+	it "detects duplicate identity keys" do
+		index = Sus::Filter::Index.new
+		identity = FakeIdentity.new("duplicate")
+		
+		index.insert(identity, child)
+		
+		expect do
+			index.insert(identity, child)
+		end.to raise_exception(KeyError, message: be =~ /duplicate/)
+	end
+end

--- a/test/sus/have.rb
+++ b/test/sus/have.rb
@@ -8,6 +8,12 @@ User = Struct.new(:name, :age)
 require "socket"
 
 describe Sus::Have do
+	def render(predicate)
+		buffer = Sus::Output::Buffered.new
+		predicate.print(buffer)
+		return buffer.string
+	end
+	
 	describe User do
 		let(:user) {subject.new("Sus", 20)}
 		
@@ -17,10 +23,18 @@ describe Sus::Have do
 				age: be >= 20
 			)
 		end
+		
+		it "can print attribute predicates" do
+			expect(render(have_attributes(name: be == "Sus"))).to be == "have {attribute name be == \"Sus\"}"
+		end
 	end
 	
 	describe Hash do
 		let(:hash) {subject[:name => "Sus", "age" => 20]}
+		
+		it "can print key predicates" do
+			expect(render(have_keys(:name, "age" => be >= 20))).to be == "have {key :name , key \"age\" be >= 20}"
+		end
 		
 		it "has keys with values" do
 			expect(hash).to have_keys(
@@ -59,6 +73,10 @@ describe Sus::Have do
 	describe Array do
 		let(:array) {[1, 2, 3]}
 		
+		it "can print value predicates" do
+			expect(render(have_value(be == 1))).to be == "have any {value be == 1}"
+		end
+		
 		it "can contain a value" do
 			expect(array).to have_value(be == 1)
 			expect(array).to have_value(be == 2)
@@ -75,6 +93,18 @@ describe Sus::Have do
 		it "doesn't contain a value" do
 			expect(array).not.to have_value(be == 4)
 			expect(array).not.to have_value(be < 1)
+		end
+		
+		it "can match all predicates" do
+			expect(array).to have(be(:include?, 1), be(:include?, 2))
+		end
+		
+		it "can match any predicate" do
+			expect(array).to have_any(be(:include?, 4), be(:include?, 2))
+		end
+		
+		it "can print any predicates" do
+			expect(render(have_any(be(:include?, 1), be(:include?, 2)))).to be == "have any {be include? 1, be include? 2}"
 		end
 	end
 	

--- a/test/sus/have_duration.rb
+++ b/test/sus/have_duration.rb
@@ -4,6 +4,16 @@
 # Copyright, 2021-2022, by Samuel Williams.
 
 describe Sus::HaveDuration do
+	def render(predicate)
+		buffer = Sus::Output::Buffered.new
+		predicate.print(buffer)
+		return buffer.string
+	end
+	
+	it "can print" do
+		expect(render(have_duration(be >= 0.01))).to be == "have duration be >= 0.01"
+	end
+	
 	it "can have a duration for a short sleep" do
 		expect{sleep 0.01}.to have_duration(be >= 0.01)
 	end

--- a/test/sus/identity.rb
+++ b/test/sus/identity.rb
@@ -64,5 +64,54 @@ describe Sus::Identity do
 			scoped_identifier = identifier.scoped
 			expect(scoped_identifier.key).to be == "#{__FILE__}:#{line_number}"
 		end
+		
+		it "can scope an identifier to an explicit location" do
+			location = caller_locations(1, 1).first
+			identifier = subject.new(location.path, "test")
+			
+			scoped_identifier = identifier.scoped([location])
+			
+			expect(scoped_identifier.line).to be == location.lineno
+		end
+	end
+	
+	with "#to_location" do
+		it "returns an expanded path and line" do
+			location = subject.new("file.rb", "file", 123).to_location
+			
+			expect(location[:path]).to be == File.expand_path("file.rb")
+			expect(location[:line]).to be == 123
+		end
+	end
+	
+	with "#match?" do
+		let(:identifier) {subject.new("file.rb", "file", 123)}
+		
+		it "matches another identity" do
+			expect(identifier.match?(subject.new("file.rb", "file", 123))).to be_nil
+		end
+		
+		it "does not match a different path" do
+			expect(identifier.match?(subject.new("other.rb", "file", 123))).to be == false
+		end
+		
+		it "does not match a different name" do
+			expect(identifier.match?(subject.new("file.rb", "other", 123))).to be == false
+		end
+		
+		it "does not match a different line" do
+			expect(identifier.match?(subject.new("file.rb", "file", 456))).to be == false
+		end
+	end
+	
+	with "#each" do
+		it "enumerates parent identities first" do
+			parent = subject.new("parent.rb", "parent", 1)
+			child = subject.new("child.rb", "child", 2, parent)
+			identities = []
+			child.each{|identity| identities << identity}
+			
+			expect(identities).to be == [parent, child]
+		end
 	end
 end

--- a/test/sus/it.rb
+++ b/test/sus/it.rb
@@ -47,6 +47,36 @@ describe Sus::It do
 			
 			expect(assertions.output.string).to be =~ /skipped test/
 		end
+		
+		it "can skip when a method is not defined" do
+			context = Sus::It.build(self.class, "test") do
+				skip_unless_method_defined(:missing_method, String)
+			end
+			
+			context.call(assertions)
+			
+			expect(assertions.output.string).to be(:include?, "missing_method")
+		end
+		
+		it "can skip when a constant is not defined" do
+			context = Sus::It.build(self.class, "test") do
+				skip_unless_constant_defined(:MissingConstant)
+			end
+			
+			context.call(assertions)
+			
+			expect(assertions.output.string).to be(:include?, "MissingConstant")
+		end
+		
+		it "can skip when the platform is not supported" do
+			context = Sus::It.build(self.class, "test") do
+				skip_if_ruby_platform(/#{Regexp.escape(RUBY_PLATFORM)}/)
+			end
+			
+			context.call(assertions)
+			
+			expect(assertions.output.string).to be(:include?, "Ruby platform")
+		end
 	end
 	
 	with "ruby version requirements" do
@@ -62,6 +92,16 @@ describe Sus::It do
 			expect(assertions.count).to be == 1
 		end
 		
+		it "skips when the ruby version is too old" do
+			context = Sus::It.build(self.class, "test") do
+				skip_unless_minimum_ruby_version("1.2.11", "1.2.3")
+			end
+			
+			context.call(assertions)
+			
+			expect(assertions.output.string).to be(:include?, "Ruby 1.2.11 is required")
+		end
+		
 		it "compares maximum ruby versions semantically" do
 			context = Sus::It.build(self.class, "test") do
 				skip_if_maximum_ruby_version("1.2.11", "1.2.3")
@@ -73,6 +113,34 @@ describe Sus::It do
 			expect(assertions.skipped).to be(:empty?)
 			expect(assertions.count).to be == 1
 		end
+		
+		it "skips when the ruby version is too new" do
+			context = Sus::It.build(self.class, "test") do
+				skip_if_maximum_ruby_version("1.2.3", "1.2.11")
+			end
+			
+			context.call(assertions)
+			
+			expect(assertions.output.string).to be(:include?, "Ruby 1.2.3 is not supported")
+		end
+		
+		it "compares equal ruby versions" do
+			context = Sus::It.build(self.class, "test") do
+				skip_unless_minimum_ruby_version("1.2.3", "1.2.3")
+				assert(true)
+			end
+			
+			context.call(assertions)
+			
+			expect(assertions.skipped).to be(:empty?)
+			expect(assertions.count).to be == 1
+		end
+	end
+	
+	it "has a string representation" do
+		context = Sus::It.build(self.class, "test"){}
+		
+		expect(context.to_s).to be == "it test"
 	end
 	
 	with "unique:" do

--- a/test/sus/it_behaves_like.rb
+++ b/test/sus/it_behaves_like.rb
@@ -33,3 +33,28 @@ with "a falsey thing" do
 		let(:thing) {true}
 	end
 end
+
+describe Sus::ItBehavesLike do
+	it "can print itself" do
+		shared = Sus::Shared("shared"){}
+		context = subject.build(Sus.base, shared)
+		output = Sus::Output.buffered
+		
+		context.print(output)
+		
+		expect(output.string).to be(:include?, "it behaves like")
+	end
+end
+
+describe Sus::Shared do
+	it "can be prepended" do
+		shared = Sus::Shared("prepended") do
+			@prepended_value = :value
+		end
+		
+		context = Sus.base
+		context.singleton_class.prepend(shared)
+		
+		expect(context.singleton_class.instance_variable_get(:@prepended_value)).to be == :value
+	end
+end

--- a/test/sus/mock.rb
+++ b/test/sus/mock.rb
@@ -34,6 +34,24 @@ end
 describe Sus::Mock do
 	let(:interface) {Interface.new}
 	
+	def render(target)
+		buffer = Sus::Output::Buffered.new
+		target.print(buffer)
+		return buffer.string
+	end
+	
+	it "can print" do
+		expect(render(Sus::Mock.new(interface))).to be =~ /mock #<.*Interface/
+	end
+	
+	it "rejects frozen targets" do
+		target = Object.new.freeze
+		
+		expect do
+			mock(target)
+		end.to raise_exception(StandardError, message: be =~ /Cannot mock frozen object/)
+	end
+	
 	it "can expect a method to be called" do
 		expect(interface).to receive(:implementation)
 		interface.implementation
@@ -143,6 +161,18 @@ describe Sus::Mock do
 			end
 			
 			expect(interface.call{"Hello World"}).to be == "Hello World"
+		end
+		
+		it "doesn't affect other threads" do
+			mock(RealImplementation) do |mock|
+				mock.wrap(:new) do |original, value|
+					original.call(value * 2)
+				end
+			end
+			
+			Thread.new do
+				expect(RealImplementation.new(10).value).to be == 10
+			end.join
 		end
 	end
 end

--- a/test/sus/output/backtrace.rb
+++ b/test/sus/output/backtrace.rb
@@ -13,6 +13,17 @@ describe Sus::Output::Backtrace do
 		expect(backtrace.stack).to have_attributes(size: be >= 1)
 	end
 	
+	it "can extract native backtrace locations" do
+		error = RuntimeError.new("boom")
+		error.set_backtrace(caller)
+		
+		begin
+			raise error
+		rescue RuntimeError => error
+			expect(subject.extract_stack(error).first).to respond_to(:path)
+		end
+	end
+	
 	with "a limit of one" do
 		it "has exactly one frame" do
 			expect(backtrace.filter(limit: 1)).to have_attributes(size: be == 1)
@@ -25,6 +36,26 @@ describe Sus::Output::Backtrace do
 			expect(stack.size).to be >= 1
 			expect(stack.last.path).to be(:start_with?, identity.path)
 		end
+	end
+	
+	it "can print multiple frames" do
+		output = Sus::Output.buffered
+		backtrace.print(output)
+		
+		expect(output.string).to be(:include?, __FILE__)
+	end
+	
+	it "can filter matching frames after the preface" do
+		stack = [
+			Sus::Output::Backtrace::Location.new("/tmp/one.rb", 1, "one"),
+			Sus::Output::Backtrace::Location.new(__FILE__, 2, "two"),
+			Sus::Output::Backtrace::Location.new(__FILE__, 3, "three"),
+			Sus::Output::Backtrace::Location.new("/tmp/four.rb", 4, "four"),
+		]
+		
+		backtrace = subject.new(stack, __dir__)
+		
+		expect(backtrace.filter.map(&:label)).to be == ["one", "two", "three"]
 	end
 	
 	with "a wonky exception" do

--- a/test/sus/output/bar.rb
+++ b/test/sus/output/bar.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "sus/output/bar"
+require "sus/output/text"
+
+describe Sus::Output::Bar do
+	let(:io) {StringIO.new}
+	let(:output) {Sus::Output::Text.new(io)}
+	
+	def before
+		Sus::Output::Bar.register(output)
+	end
+	
+	it "registers progress bar output style" do
+		expect(output.styles).to be(:include?, :progress_bar)
+	end
+	
+	it "can print an empty progress bar" do
+		bar = subject.new
+		bar.print(output)
+		
+		expect(io.string).to be == (" " * output.width) + "\n"
+	end
+	
+	it "can print progress with a message" do
+		bar = subject.new(5, 10, "Loading")
+		bar.print(output)
+		
+		expect(io.string).to be(:start_with?, "Loading: ")
+		expect(io.string).to be(:include?, "█")
+	end
+	
+	it "can omit messages that don't fit" do
+		bar = subject.new(1, 2, "x" * 100)
+		bar.print(output)
+		
+		expect(io.string).not.to be(:include?, "x")
+		expect(io.string).to be(:include?, "█")
+	end
+	
+	it "can update progress" do
+		bar = subject.new
+		bar.update(1, 2, nil)
+		bar.print(output)
+		
+		expect(io.string).to be(:include?, "█")
+	end
+end

--- a/test/sus/output/buffered.rb
+++ b/test/sus/output/buffered.rb
@@ -43,4 +43,21 @@ describe Sus::Output::Buffered do
 			expect(assertions.output.string).to be =~ /StatefulThing initial/
 		end
 	end
+	
+	it "can inspect buffers with tee output" do
+		tee = Sus::Output.buffered
+		buffer = subject.new(tee)
+		
+		expect(buffer.inspect).to be(:include?, "->")
+	end
+	
+	it "can print itself to output" do
+		buffer = subject.new
+		buffer.write("hello")
+		
+		output = Sus::Output.buffered
+		buffer.print(output)
+		
+		expect(output.string).to be == "hello"
+	end
 end

--- a/test/sus/output/lines.rb
+++ b/test/sus/output/lines.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "sus/output/lines"
+require "sus/output/status"
+require "sus/output/text"
+
+describe Sus::Output::Lines do
+	let(:io) {StringIO.new}
+	let(:output) {Sus::Output::Text.new(io)}
+	let(:lines) {subject.new(output)}
+	
+	it "can write and clear lines" do
+		lines[0] = Sus::Output::Status.new(:free, "idle")
+		lines[1] = nil
+		
+		lines.clear
+		
+		expect(io.string).to be(:include?, "idle")
+		expect(io.string).to be(:include?, "\e[?7l")
+		expect(io.string).to be(:include?, "\e[?7h")
+	end
+	
+	it "can update an existing line" do
+		lines[0] = Sus::Output::Status.new(:free, "idle")
+		io.truncate(0)
+		io.rewind
+		
+		lines[0] = Sus::Output::Status.new(:busy, "busy")
+		
+		expect(io.string).to be(:include?, "\e[1F\e[K")
+		expect(io.string).to be(:include?, "busy")
+	end
+	
+	it "can move back after updating earlier lines" do
+		lines[0] = Sus::Output::Status.new(:free, "one")
+		lines[1] = Sus::Output::Status.new(:free, "two")
+		io.truncate(0)
+		io.rewind
+		
+		lines[0] = Sus::Output::Status.new(:free, "one again")
+		
+		expect(io.string).to be(:include?, "\e[2F\e[K")
+		expect(io.string).to be(:include?, "\e[1E")
+	end
+end

--- a/test/sus/output/progress.rb
+++ b/test/sus/output/progress.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "sus/output/progress"
+require "sus/output/text"
+
+describe Sus::Output::Progress do
+	let(:io) {StringIO.new}
+	let(:output) {Sus::Output::Text.new(io)}
+	
+	it "can track non-interactive progress" do
+		progress = subject.new(output, 4)
+		
+		expect(progress.current).to be == 0
+		expect(progress.total).to be == 4
+		expect(progress.remaining).to be == 4
+		expect(progress.progress).to be == 0.0
+		expect(progress.average_duration).to be_nil
+		expect(progress.estimated_remaining_time).to be_nil
+		expect(progress.to_s).to be == "0/4 completed"
+		
+		expect(progress.increment(2)).to be_equal(progress)
+		expect(progress.expand(2)).to be_equal(progress)
+		
+		expect(progress.current).to be == 2
+		expect(progress.total).to be == 6
+		expect(progress.remaining).to be == 4
+		expect(progress.to_s).to be(:include?, "2/6 completed")
+	end
+	
+	it "can render interactive progress" do
+		output.define_singleton_method(:interactive?){true}
+		
+		progress = subject.new(output, 2)
+		progress.report(0, "first", :busy)
+		progress.increment
+		progress.clear
+		
+		expect(io.string).to be(:include?, "first")
+		expect(io.string).to be(:include?, "\e[?7l")
+	end
+	
+	it "formats long durations" do
+		progress = subject.new(output, 2)
+		
+		progress.instance_variable_set(:@start_time, subject.now - 90.0)
+		progress.increment
+		expect(progress.to_s).to be(:include?, "1m")
+		
+		progress.instance_variable_set(:@start_time, subject.now - (2 * 60 * 60))
+		expect(progress.to_s).to be(:include?, "2h")
+		
+		progress.instance_variable_set(:@start_time, subject.now - (3 * 24 * 60 * 60))
+		expect(progress.to_s).to be(:include?, "3d")
+	end
+end

--- a/test/sus/output/status.rb
+++ b/test/sus/output/status.rb
@@ -30,4 +30,10 @@ describe Sus::Output::Status do
 		status.print(output)
 		expect(buffer.string).to be =~ /[◑◒◐◓] \n/
 	end
+	
+	it "can print unknown status indicator" do
+		status.update(:unknown)
+		status.print(output)
+		expect(buffer.string).to be == "  \n"
+	end
 end

--- a/test/sus/output/text.rb
+++ b/test/sus/output/text.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "sus/output"
+
+class InteractiveStringIO < StringIO
+	def isatty
+		true
+	end
+	
+	def winsize
+		[24, 80]
+	end
+end
+
+describe Sus::Output do
+	it "can create xterm output for interactive IO" do
+		output = subject.for(InteractiveStringIO.new, {})
+		
+		expect(output).to be_a(Sus::Output::XTerm)
+	end
+end
+
+describe Sus::Output::Text do
+	let(:io) {StringIO.new}
+	let(:output) {subject.new(io)}
+	
+	it "does not support colors" do
+		expect(output.colors?).to be == false
+	end
+	
+	it "can write proc arguments" do
+		output.write(->(output){output.write("called")})
+		
+		expect(io.string).to be == "called"
+	end
+	
+	it "can write inverted assertion prefixes" do
+		output.assert(true, false, "expected failure", Sus::Output::Backtrace.new([]))
+		output.assert(false, false, "expected failure", Sus::Output::Backtrace.new([]))
+		
+		expect(io.string).to be(:include?, "expected failure")
+	end
+	
+	it "can write multiline errors with causes" do
+		cause = RuntimeError.new("cause")
+		
+		begin
+			raise cause
+		rescue
+			begin
+				raise RuntimeError, "line 1\nline 2"
+			rescue RuntimeError => error
+				output.error(error, nil)
+			end
+		end
+		
+		expect(io.string).to be(:include?, "line 2")
+		expect(io.string).to be(:include?, "Caused by")
+	end
+end

--- a/test/sus/output/variable.rb
+++ b/test/sus/output/variable.rb
@@ -44,6 +44,12 @@ describe Sus::Output::Variable do
 			expect(inspect_string(array)).to be == "[1, [...]]"
 		end
 		
+		it "handles recursive hashes" do
+			hash = {}
+			hash[:self] = hash
+			expect(inspect_string(hash)).to be == "{self: {...}}"
+		end
+		
 		it "truncates objects with long inspect output" do
 			object = Object.new
 			object.define_singleton_method(:inspect){"#<Big #{"x" * 200}>"}
@@ -66,6 +72,13 @@ describe Sus::Output::Variable do
 	end
 	
 	with ".format" do
+		it "can disable truncation" do
+			buffer = Sus::Output::Buffered.new
+			Sus::Output::Variable.format(buffer, "x" * 200, limit: nil)
+			
+			expect(buffer.string).to be == ("x" * 200).inspect
+		end
+		
 		it "emits the value in a single style" do
 			buffer = Sus::Output::Buffered.new
 			Sus::Output::Variable.format(buffer, {"key" => 42, :sym => "value"})

--- a/test/sus/output/xterm.rb
+++ b/test/sus/output/xterm.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "sus/output/xterm"
+
+class WindowedStringIO < StringIO
+	def winsize
+		[30, 120]
+	end
+end
+
+describe Sus::Output::XTerm do
+	let(:io) {WindowedStringIO.new}
+	let(:output) {subject.new(io)}
+	
+	it "supports colors" do
+		expect(output.colors?).to be == true
+	end
+	
+	it "uses terminal size" do
+		expect(output.size).to be == [30, 120]
+	end
+	
+	it "can create styles" do
+		expect(output.style(:red, :white, :bold, 4)).to be == "\e[31;47;1;4m"
+	end
+	
+	it "can reset styles" do
+		expect(output.reset).to be == "\e[0m"
+	end
+end

--- a/test/sus/raise_exception.rb
+++ b/test/sus/raise_exception.rb
@@ -13,6 +13,22 @@ class AgeError < StandardError
 end
 
 describe Sus::RaiseException do
+	def render(predicate)
+		buffer = Sus::Output::Buffered.new
+		predicate.print(buffer)
+		return buffer.string
+	end
+	
+	it "can print with an additional predicate" do
+		expect(render(raise_exception(RuntimeError).and(have_attributes(message: be =~ /Boom/)))).to be =~ / and /
+	end
+	
+	it "can raise an exception without matching a message" do
+		expect do
+			raise "Boom"
+		end.to raise_exception(RuntimeError)
+	end
+	
 	it "can raise an exception with a matching message" do
 		expect do
 			raise "Boom"

--- a/test/sus/receive.rb
+++ b/test/sus/receive.rb
@@ -28,6 +28,16 @@ end
 describe Sus::Receive do
 	let(:interface) {Interface.new}
 	
+	def render(predicate)
+		buffer = Sus::Output::Buffered.new
+		predicate.print(buffer)
+		return buffer.string
+	end
+	
+	it "can print" do
+		expect(render(receive(:implementation))).to be == "receive implementation"
+	end
+	
 	it "can validate a method call" do
 		expect(interface).to receive(:implementation)
 		expect(interface).to be(:kind_of?, Interface)
@@ -35,6 +45,12 @@ describe Sus::Receive do
 	end
 	
 	with "#and_return" do
+		it "raises an error for values and a block" do
+			expect do
+				receive(:implementation).and_return(:value){:other}
+			end.to raise_exception(ArgumentError, message: be =~ /both/)
+		end
+		
 		it "can return a specific value" do
 			expect(interface).to receive(:implementation).and_return(FakeImplementation.new)
 			
@@ -89,6 +105,10 @@ describe Sus::Receive do
 	end
 	
 	describe Sus::Receive::Times do
+		it "can print" do
+			expect(render(subject.new(be >= 1))).to be == "with call count be >= 1"
+		end
+		
 		it "expects at least one call by default" do
 			expect(interface).to receive(:implementation)
 			
@@ -100,6 +120,44 @@ describe Sus::Receive do
 			
 			interface.implementation
 			interface.implementation
+		end
+		
+		it "can expect one call" do
+			expect(interface).to receive(:implementation).once
+			
+			interface.implementation
+		end
+		
+		it "can expect two calls" do
+			expect(interface).to receive(:implementation).twice
+			
+			interface.implementation
+			interface.implementation
+		end
+		
+		it "can expect a matching call count" do
+			expect(interface).to receive(:implementation).with_call_count(be >= 2)
+			
+			interface.implementation
+			interface.implementation
+		end
+	end
+	
+	describe Sus::Receive::WithArguments do
+		it "can print" do
+			expect(render(subject.new(be == [:value]))).to be == "with arguments be == [:value]"
+		end
+	end
+	
+	describe Sus::Receive::WithOptions do
+		it "can print" do
+			expect(render(subject.new(be == {key: :value}))).to be == "with options be == {key: :value}"
+		end
+	end
+	
+	describe Sus::Receive::WithBlock do
+		it "can print" do
+			expect(render(subject.new(be(:lambda?)))).to be == "with blockbe lambda?"
 		end
 	end
 end

--- a/test/sus/registry.rb
+++ b/test/sus/registry.rb
@@ -23,4 +23,14 @@ describe Sus::Registry do
 		expect(found_files).to have_value(be =~ /directory_test_file\.rb/)
 		expect(found_files).to have_value(be =~ /nested_directory_test_file\.rb/)
 	end
+	
+	it "delegates children and enumeration to the base context" do
+		registry.load(__FILE__)
+		
+		children = []
+		registry.each{|child| children << child}
+		
+		expect(registry.children).not.to be(:empty?)
+		expect(children).not.to be(:empty?)
+	end
 end

--- a/test/sus/respond_to.rb
+++ b/test/sus/respond_to.rb
@@ -6,10 +6,23 @@
 class Interface
 	def method_with_options(x: 10, y:)
 	end
+	
+	def method_with_parameters(x, y = nil, **options)
+	end
 end
 
 describe Sus::RespondTo do
 	let(:interface) {Interface.new}
+	
+	def render(predicate)
+		buffer = Sus::Output::Buffered.new
+		predicate.print(buffer)
+		return buffer.string
+	end
+	
+	it "can print" do
+		expect(render(respond_to(:method_with_options))).to be == "respond to method_with_options"
+	end
 	
 	it "can respond to a method" do
 		expect(interface).to respond_to(:method_with_options)
@@ -29,5 +42,27 @@ describe Sus::RespondTo do
 	
 	it "fails to respond to non-existant method" do
 		expect(interface).not.to respond_to(:non_existant_method)
+	end
+	
+	describe Sus::RespondTo::WithParameters do
+		it "can match required and optional parameters" do
+			assertions = Sus::Assertions.new
+			subject.new([:x, :y]).call(assertions, interface.method(:method_with_parameters).parameters)
+			
+			expect(assertions).to be(:passed?)
+		end
+		
+		it "can stop after expected parameters are exhausted" do
+			assertions = Sus::Assertions.new
+			subject.new([:x]).call(assertions, interface.method(:method_with_parameters).parameters)
+			
+			expect(assertions).to be(:passed?)
+		end
+	end
+	
+	describe Sus::RespondTo::WithOptions do
+		it "can print" do
+			expect(render(subject.new([:x, :y]))).to be == "with options [:x, :y]"
+		end
 	end
 end

--- a/test/sus/tree.rb
+++ b/test/sus/tree.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "json"
+
+describe Sus::Tree do
+	let(:root) {Sus::Describe.build(Sus.base, "root")}
+	let(:child) {Sus::It.build(root, "child"){}}
+	let(:tree) {subject.new(root)}
+	
+	def before
+		root.add(child)
+	end
+	
+	it "can traverse contexts" do
+		result = tree.traverse do |context|
+			context.description
+		end
+		
+		expect(result).to be == {
+			self: "root",
+			children: [
+				{self: "child"}
+			]
+		}
+	end
+	
+	with "#to_json" do
+		it "can be converted to JSON" do
+			result = JSON.parse(tree.to_json)
+			
+			expect(result["self"]).to be == [root.identity.to_s, "root", false]
+			expect(result["children"].first["self"]).to be == [child.identity.to_s, "child", true]
+		end
+	end
+end

--- a/test/sus/with.rb
+++ b/test/sus/with.rb
@@ -16,7 +16,7 @@ describe Sus::With do
 		it "can print context name" do
 			buffer = Sus::Output.buffered
 			context.print(buffer)
-			expect(buffer.string).to be =~ %r{describe Sus::With with nested contexts it can print context name test/sus/with.rb:\d+ with a test variable}
+			expect(buffer.string).to be =~ %r{a test variable}
 		end
 	end
 	


### PR DESCRIPTION
## Summary

- Add focused coverage for tree/filter traversal, output variable edge cases, predicate rendering, receive modifiers, mock branches, and respond_to constraints.
- Add executable coverage for `bin/sus` by spawning it from tests and relying on Covered's `RUBYOPT=-rcovered/autostart` propagation.
- Restrict child executable coverage to `bin/sus` with `SUS_COVER_BIN_ONLY` so fixture runs don't persist partial library coverage.
- Fix predicate composition for `Sus::Be::And#|` and `Sus::Be::Or#&` so they pass arrays to the compound predicate constructors.
- Fix `RespondTo::WithParameters` so expected parameters advance for each checked method parameter.

## Tests

- `rm -f .covered.db && COVERAGE=PartialSummary bundle exec bake test` (48 files checked; 697/697 lines executed; 100.0% covered)
- `bundle exec bake covered:validate --paths .covered.db \;`
- `bundle exec sus test/sus/bin.rb`
- `git diff --check`