### PR TITLE
Enable verbose output from CI debug environment variables.

### DIFF
--- a/lib/sus/config.rb
+++ b/lib/sus/config.rb
@@ -38,10 +38,38 @@ module Sus
 			end
 			
 			options = {
-				verbose: !!arguments.delete("--verbose")
+				verbose: !!arguments.delete("--verbose") || self.verbose_from_environment?
 			}
 			
 			return derived.new(root, arguments, **options)
+		end
+		
+		# Maps CI environment variables to the values they take when the CI provider is running in debug/verbose mode. When any of these match, we enable verbose output automatically.
+		#
+		# - `RUNNER_DEBUG` is set by GitHub Actions when a workflow is re-run with "Enable debug logging".
+		# - `CI_DEBUG_TRACE` is set by GitLab CI when debug logging (tracing) is enabled.
+		# - `BUILDKITE_AGENT_DEBUG` is set by Buildkite when agent debug is enabled.
+		# - `SYSTEM_DEBUG` is set by Azure Pipelines when the `system.debug` variable is enabled.
+		# - `SUS_VERBOSE` can be set explicitly to enable verbose output regardless of the CI provider.
+		DEBUG_ENVIRONMENT = {
+			"SUS_VERBOSE" => "true",
+			"RUNNER_DEBUG" => "1",
+			"CI_DEBUG_TRACE" => "true",
+			"BUILDKITE_AGENT_DEBUG" => "true",
+			"SYSTEM_DEBUG" => "true",
+		}
+		
+		# Whether verbose output should be enabled based on the environment.
+		#
+		# Detects CI environments that request debug logging, e.g. GitHub Actions
+		# sets `RUNNER_DEBUG=1` when a workflow is re-run with "Enable debug logging".
+		#
+		# @parameter env [Hash] The environment to inspect.
+		# @returns [Boolean] Whether verbose output should be enabled.
+		def self.verbose_from_environment?(env = ENV)
+			DEBUG_ENVIRONMENT.any? do |key, value|
+				env[key] == value
+			end
 		end
 		
 		# Initialize a new Config instance.

--- a/lib/sus/config.rb
+++ b/lib/sus/config.rb
@@ -27,8 +27,9 @@ module Sus
 		# Load configuration from the given root directory.
 		# @parameter root [String] The root directory to load configuration from.
 		# @parameter arguments [Array] Command line arguments to parse.
+		# @parameter env [Hash] The environment to inspect for debug/verbose settings.
 		# @returns [Config] A new Config instance.
-		def self.load(root: Dir.pwd, arguments: ARGV)
+		def self.load(root: Dir.pwd, arguments: ARGV, env: ENV)
 			derived = Class.new(self)
 			
 			if path = self.path(root)
@@ -38,7 +39,7 @@ module Sus
 			end
 			
 			options = {
-				verbose: !!arguments.delete("--verbose") || self.verbose_from_environment?
+				verbose: !!arguments.delete("--verbose") || self.verbose_from_environment?(env)
 			}
 			
 			return derived.new(root, arguments, **options)

--- a/test/sus/config.rb
+++ b/test/sus/config.rb
@@ -22,6 +22,48 @@ describe Sus::Config do
 		expect(config).not.to be(:nil?)
 	end
 	
+	with ".verbose_from_environment?" do
+		it "is enabled by GitHub Actions debug logging" do
+			expect(subject.verbose_from_environment?({"RUNNER_DEBUG" => "1"})).to be == true
+		end
+		
+		it "is enabled by GitLab CI debug tracing" do
+			expect(subject.verbose_from_environment?({"CI_DEBUG_TRACE" => "true"})).to be == true
+		end
+		
+		it "is enabled by Buildkite agent debug" do
+			expect(subject.verbose_from_environment?({"BUILDKITE_AGENT_DEBUG" => "true"})).to be == true
+		end
+		
+		it "is enabled by Azure Pipelines system debug" do
+			expect(subject.verbose_from_environment?({"SYSTEM_DEBUG" => "true"})).to be == true
+		end
+		
+		it "is enabled by the SUS_VERBOSE environment variable" do
+			expect(subject.verbose_from_environment?({"SUS_VERBOSE" => "true"})).to be == true
+		end
+		
+		it "is disabled by default" do
+			expect(subject.verbose_from_environment?({})).to be == false
+		end
+		
+		it "ignores unrelated values" do
+			expect(subject.verbose_from_environment?({"RUNNER_DEBUG" => "0"})).to be == false
+		end
+	end
+	
+	with "#verbose?" do
+		it "is enabled by the --verbose argument" do
+			config = subject.load(root: root, arguments: ["--verbose"])
+			expect(config).to be(:verbose?)
+		end
+		
+		it "is disabled by default" do
+			config = subject.load(root: root, arguments: [])
+			expect(config).not.to be(:verbose?)
+		end
+	end
+	
 	with "summary output" do
 		let(:io) {StringIO.new}
 		let(:output) {Sus::Output::Text.new(io)}

--- a/test/sus/config.rb
+++ b/test/sus/config.rb
@@ -54,12 +54,17 @@ describe Sus::Config do
 	
 	with "#verbose?" do
 		it "is enabled by the --verbose argument" do
-			config = subject.load(root: root, arguments: ["--verbose"])
+			config = subject.load(root: root, arguments: ["--verbose"], env: {})
+			expect(config).to be(:verbose?)
+		end
+		
+		it "is enabled by the environment" do
+			config = subject.load(root: root, arguments: [], env: {"SUS_VERBOSE" => "true"})
 			expect(config).to be(:verbose?)
 		end
 		
 		it "is disabled by default" do
-			config = subject.load(root: root, arguments: [])
+			config = subject.load(root: root, arguments: [], env: {})
 			expect(config).not.to be(:verbose?)
 		end
 	end


### PR DESCRIPTION
## Summary

When a CI provider is re-run in debug/verbose mode, sus now automatically enables verbose output (equivalent to passing `--verbose`). The most common case is GitHub Actions: re-running a workflow with **"Enable debug logging"** sets `RUNNER_DEBUG=1`, which we now detect.

## Supported environment variables

| Variable | Provider | Value |
|---|---|---|
| `SUS_VERBOSE` | (our own explicit toggle) | `true` |
| `RUNNER_DEBUG` | GitHub Actions | `1` |
| `CI_DEBUG_TRACE` | GitLab CI | `true` |
| `BUILDKITE_AGENT_DEBUG` | Buildkite | `true` |
| `SYSTEM_DEBUG` | Azure Pipelines | `true` |

`--verbose` continues to work as before; the environment check is an additional trigger.

## Tests

Added coverage for `Config.verbose_from_environment?` (each provider, defaults, unrelated values) and `Config#verbose?` (the `--verbose` argument). Full suite passes (287 tests).